### PR TITLE
Stub methods returns should be over writable

### DIFF
--- a/src/StubbedActionMatcherRepo.ts
+++ b/src/StubbedActionMatcherRepo.ts
@@ -11,12 +11,13 @@ export class StubbedActionMatcherRepo {
         this.recordCall(propertyKey, argsToMatch);
         const stubbedActionMatchers = this.stubbedActionMatcherMap[propertyKey] || [];
 
-        const [firstMatchedMatcher] =
+        const [lastMatchedMatcher] =
             stubbedActionMatchers
-                .filter((matcher: StubbedActionMatcher) => matcher.match(argsToMatch));
+                .filter((matcher: StubbedActionMatcher) => matcher.match(argsToMatch))
+                .reverse();
 
-        if (firstMatchedMatcher) {
-            return LookupResult.returnValueFound(firstMatchedMatcher);
+        if (lastMatchedMatcher) {
+            return LookupResult.returnValueFound(lastMatchedMatcher);
         } else {
             return LookupResult.noReturnValueMatched(
                 new WhyNoReturnValueMatched(argsToMatch, stubbedActionMatchers, propertyKey)

--- a/test/SafeMock.test.ts
+++ b/test/SafeMock.test.ts
@@ -175,6 +175,15 @@ describe('SafeMock', () => {
                     when("this is no good").return("holla")
                 }).to.throw("Whoops! Looks like you called `when` incorrectly. Make sure you create a Mock First!");
             });
+
+            it("allows generic return values to be overridden", () => {
+                const mock: Mock<SomeService> = SafeMock.build<SomeService>();
+
+                when(mock.createSomethingOneArg).return("original coke");
+                when(mock.createSomethingOneArg).return("new coke");
+
+                expect(mock.createSomethingOneArg("not used")).to.equal("new coke");
+            });
         });
 
         describe("making mocks throw", () => {


### PR DESCRIPTION
For mocked methods, let's let users change their minds about what they want to return.

I was struggling to get this to work for a mock with args in the when, but this does work fine for any arg matchers.