### PR TITLE
Source maps / inline sources for easier debugging

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "noImplicitThis": true,
     "strictNullChecks": true,
     "noImplicitReturns": true,
-    "sourceMap": false,
+    "sourceMap": true,
+    "inlineSources": true,
     "declaration": false
   }
 }


### PR DESCRIPTION
More of a conversation starter then something that you may want to accept.

Adding the lines below makes the debugger work out of the box with WebStorm. Any specific reason we would not want this?