### PR TITLE
Void promise resolve helper

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,6 +13,7 @@ export interface ReturnSetter<T> {
 
 export interface PromiseReturnSetter<T> extends ReturnSetter<Promise<T>> {
     resolve(rejection: T): void;
+    resolveVoid(): void;
     reject(rejection: any): void;
 }
 

--- a/src/StubbedActionMatcher.ts
+++ b/src/StubbedActionMatcher.ts
@@ -66,6 +66,17 @@ export class ResolvedPromiseAction implements StubbedAction {
     }
 }
 
+export class VoidResolvedPromiseAction implements StubbedAction {
+
+    performMockedReturnValue(): any {
+        return Promise.resolve();
+    }
+
+
+    static of() {
+        return new VoidResolvedPromiseAction();
+    }
+}
 
 export interface StubbedAction {
     performMockedReturnValue(): any

--- a/src/valueIfNoReturnValueSet.ts
+++ b/src/valueIfNoReturnValueSet.ts
@@ -2,7 +2,7 @@ import WhyReturnValueDidntMatch from "./WhyNoReturnValueMatched";
 import _setStubbedActionNoArgs from "./_setStubbedActionNoArgsSymbol";
 import {
     ReturnValueAction, ThrowingAction, RejectedPromiseAction, StubbedAction,
-    ResolvedPromiseAction
+    ResolvedPromiseAction, VoidResolvedPromiseAction
 } from "./StubbedActionMatcher";
 import {PromiseReturnSetter, When} from "../index";
 
@@ -26,6 +26,10 @@ class SafeMockReturnSetter<T> implements PromiseReturnSetter<T> {
 
     resolve(resolvedValue: any): void {
         this.stubbedActionSetter(ResolvedPromiseAction.of(resolvedValue));
+    }
+
+    resolveVoid(): void {
+        this.stubbedActionSetter(VoidResolvedPromiseAction.of());
     }
 
     reject(rejection: any): void {

--- a/test/SafeMock.test.ts
+++ b/test/SafeMock.test.ts
@@ -255,6 +255,23 @@ describe('SafeMock', () => {
                         }
                     )
             });
+
+            it("allows setting promise resolved with a void directly", () => {
+                interface PromiseSomeService {
+                    someMethodThatReturnsAPromise(): Promise<void>;
+                }
+
+                const mock: Mock<PromiseSomeService> = SafeMock.build<PromiseSomeService>();
+
+                when(mock.someMethodThatReturnsAPromise()).resolveVoid();
+
+                return mock.someMethodThatReturnsAPromise()
+                    .then(
+                        (resolvedValue) => {
+                            expect(resolvedValue).to.be.undefined
+                        }
+                    )
+            });
         });
 
         describe("No Return Value Set", () => {


### PR DESCRIPTION
Convenience function to resolve void promises.

There is a type hole here, but that is also true for `resolve` method as well.

For example, adding `expect(resolvedValue).to.eql(5);` to the following test:

```typescript
it("allows setting promise resolved directly", () => {
    interface PromiseSomeService {
        someMethodThatReturnsAPromise(): Promise<string>;
    }

    const mock: Mock<PromiseSomeService> = SafeMock.build<PromiseSomeService>();

    when(mock.someMethodThatReturnsAPromise()).resolve("Value to resolve");

    return mock.someMethodThatReturnsAPromise()
        .then(
            (resolvedValue) => {
                expect(resolvedValue).to.eql("Value to resolve");
                expect(resolvedValue).to.eql(5);
            }
        )
});
```

will not cause a compile time error,
