### PR TITLE
upgrade typescript to 3.1.3 & replace strict mapping to partial in calledWith function

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -47,61 +47,61 @@ export interface CallVerifierNoArgs {
 }
 export interface CallVerifier1<K> {
     called(): void;
-    calledWith(k: K): void;
+    calledWith(k: Partial<K>): void;
     times(k: number): any;
     never: CallVerifier1<K>;
 }
 export interface CallVerifier2<K, L> {
     called(): void;
-    calledWith(k: K, l: L): void;
+    calledWith(k: Partial<K>, l: Partial<L>): void;
     never: CallVerifier2<K, L>;
     times(k: number): any;
 }
 export interface CallVerifier3<K, L, J> {
     called(): void;
-    calledWith(k: K, l: L, j: J): void;
+    calledWith(k: Partial<K>, l: Partial<L>, j: Partial<J>): void;
     never: CallVerifier3<K, L, J>;
     times(k: number): any;
 }
 export interface CallVerifier4<K, L, J, A> {
     called(): void;
-    calledWith(k: K, l: L, j: J, a: A): void;
+    calledWith(k: Partial<K>, l: Partial<L>, j: Partial<J>, a: Partial<A>): void;
     never: CallVerifier4<K, L, J, A>;
     times(k: number): any;
 }
 export interface CallVerifier5<K, L, J, A, B> {
     called(): void;
-    calledWith(k: K, l: L, j: J, a: A, b: B): void;
+    calledWith(k: Partial<K>, l: Partial<L>, j: Partial<J>, a: Partial<A>, b: Partial<B>): void;
     times(k: number): any;
     never: CallVerifier5<K, L, J, A, B>;
 }
 export interface CallVerifier6<K, L, J, A, B, C> {
     called(): void;
-    calledWith(k: K, l: L, j: J, a: A, b: B, c: C): void;
+    calledWith(k: Partial<K>, l: Partial<L>, j: Partial<J>, a: Partial<A>, b: Partial<B>, c: Partial<C>): void;
     times(k: number): any;
     never: CallVerifier6<K, L, J, A, B, C>;
 }
 export interface CallVerifier7<K, L, J, A, B, C, D> {
     called(): void;
-    calledWith(k: K, l: L, j: J, a: A, b: B, c: C, d: D): void;
+    calledWith(k: Partial<K>, l: Partial<L>, j: Partial<J>, a: Partial<A>, b: Partial<B>, c: Partial<C>, d: Partial<D>): void;
     times(k: number): any;
     never: CallVerifier7<K, L, J, A, B, C, D>;
 }
 export interface CallVerifier8<K, L, J, A, B, C, D, E> {
     called(): void;
-    calledWith(k: K, l: L, j: J, a: A, b: B, c: C, d: D, e: E): void;
+    calledWith(k: Partial<K>, l: Partial<L>, j: Partial<J>, a: Partial<A>, b: Partial<B>, c: Partial<C>, d: Partial<D>, e: Partial<E>): void;
     times(k: number): any;
     never: CallVerifier8<K, L, J, A, B, C, D, E>;
 }
 export interface CallVerifier9<K, L, J, A, B, C, D, E, F> {
     called(): void;
-    calledWith(k: K, l: L, j: J, a: A, b: B, c: C, d: D, e: E, f: F): void;
+    calledWith(k: Partial<K>, l: Partial<L>, j: Partial<J>, a: Partial<A>, b: Partial<B>, c: Partial<C>, d: Partial<D>, e: Partial<E>, f: Partial<F>): void;
     times(k: number): any;
     never: CallVerifier9<K, L, J, A, B, C, D, E, F>;
 }
 export interface CallVerifier10<K, L, J, A, B, C, D, E, F, X> {
     called(): void;
-    calledWith(k: K, l: L, j: J, a: A, b: B, c: C, d: D, e: E, f: F, x: X): void;
+    calledWith(k: Partial<K>, l: Partial<L>, j: Partial<J>, a: Partial<A>, b: Partial<B>, c: Partial<C>, d: Partial<D>, e: Partial<E>, f: Partial<F>, x: Partial<X>): void;
     times(k: number): any;
     never: CallVerifier10<K, L, J, A, B, C, D, E, F, X>;
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "chai": "^4.1.2",
     "mocha": "^3.5.3",
     "ts-node": "^6.0.3",
-    "typescript": "3.1.3",
+    "typescript": "2.7.2",
     "tslint": "^5.11.0",
     "source-map-support": "^0.5.5"
   }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "chai": "^4.1.2",
     "mocha": "^3.5.3",
     "ts-node": "^6.0.3",
-    "typescript": "2.8.3",
+    "typescript": "3.1.3",
     "source-map-support": "^0.5.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "mocha": "^3.5.3",
     "ts-node": "^6.0.3",
     "typescript": "3.1.3",
+    "tslint": "^5.11.0",
     "source-map-support": "^0.5.5"
   }
 }

--- a/src/CallsDontMatchError.ts
+++ b/src/CallsDontMatchError.ts
@@ -14,7 +14,8 @@ export default class CallsDontMatchError extends Error {
 
     constructor(expectedCall: ArgumentInvocation, otherInteractions: ArgumentInvocation[], methodName: PropertyKey) {
         super();
-        let message = `${methodName} was not called with: ${expectedCall.prettyPrint()}\n`;
+
+        let message = `${String(methodName)} was not called with: ${expectedCall.prettyPrint()}\n`;
 
         if (otherInteractions.length !== 0) {
             message = message + `       Other interactions with this mock: [${ prettyPrintOtherInteractions(otherInteractions)}]`;

--- a/src/StubbedActionMatcherRepo.ts
+++ b/src/StubbedActionMatcherRepo.ts
@@ -10,7 +10,7 @@ export class StubbedActionMatcherRepo {
 
     recordAndFindMatch(propertyKey: PropertyKey, argsToMatch: ArgumentInvocation): LookupResult {
         this.recordCall(propertyKey, argsToMatch);
-        const stubbedActionMatchers = this.stubbedActionMatcherMap[propertyKey] || [];
+        const stubbedActionMatchers = this.stubbedActionMatcherMap[String(propertyKey)] || [];
 
         const [lastMatchedMatcher] =
             stubbedActionMatchers
@@ -36,31 +36,31 @@ export class StubbedActionMatcherRepo {
     }
 
     private setStubbedActionMatcher(propertyKey: PropertyKey, stubbedActionMatcher: StubbedActionMatcher) {
-        if (!this.stubbedActionMatcherMap[propertyKey])
-            this.stubbedActionMatcherMap[propertyKey] = [];
+        if (!this.stubbedActionMatcherMap[String(propertyKey)])
+            this.stubbedActionMatcherMap[String(propertyKey)] = [];
 
-        this.stubbedActionMatcherMap[propertyKey].push(stubbedActionMatcher);
+        this.stubbedActionMatcherMap[String(propertyKey)].push(stubbedActionMatcher);
     }
 
     lookupCalls(propertyKey: PropertyKey): ArgumentInvocation[] {
-        return this.callMap[propertyKey] || [];
+        return this.callMap[String(propertyKey)] || [];
     }
 
     private recordCall(propertyKey: PropertyKey, argsToMatch: ArgumentInvocation) {
-        this.callMap[propertyKey] = (this.callMap[propertyKey] || []);
+        this.callMap[String(propertyKey)] = (this.callMap[String(propertyKey)] || []);
 
-        this.callMap[propertyKey].push(argsToMatch)
+        this.callMap[String(propertyKey)].push(argsToMatch)
     }
 
     resetPropertyKey(propertyKey: PropertyKey) {
-        this.stubbedActionMatcherMap[propertyKey] = [];
-        this.callMap[propertyKey] = [];
+        this.stubbedActionMatcherMap[String(propertyKey)] = [];
+        this.callMap[String(propertyKey)] = [];
     }
 
     private deleteCallRecord(propertyKey: PropertyKey, argumentInvocation: ArgumentInvocation) {
-        this.callMap[propertyKey] = (this.callMap[propertyKey] || []);
+        this.callMap[String(propertyKey)] = (this.callMap[String(propertyKey)] || []);
 
-        this.callMap[propertyKey] = this.callMap[propertyKey].filter((call) => !call.equivalentTo(argumentInvocation))
+        this.callMap[String(propertyKey)] = this.callMap[String(propertyKey)].filter((call) => !call.equivalentTo(argumentInvocation))
 
     }
 }

--- a/src/Verifier.ts
+++ b/src/Verifier.ts
@@ -19,7 +19,7 @@ export class Verifier {
         const calls = this.repo.lookupCalls(this.propertyKey);
 
         if (calls.length === 0)
-            throw new Error(`${this.propertyKey} was never called`)
+            throw new Error(`${String(this.propertyKey)} was never called`)
     }
 
     //noinspection JSUnusedGlobalSymbols
@@ -49,7 +49,7 @@ class NeverVerifier {
         const calls = this.repo.lookupCalls(this.propertyKey);
 
         if (calls.length !== 0)
-            throw new Error(`${this.propertyKey} was called ${calls.length} times`)
+            throw new Error(`${String(this.propertyKey)} was called ${calls.length} times`)
     }
 
     //noinspection JSUnusedGlobalSymbols
@@ -62,7 +62,7 @@ class NeverVerifier {
             .filter(expectedCall => expectedArgumentInvocation.equivalentTo(expectedCall));
 
         if (callsWithMatchingArgs.length !== 0) {
-            throw new Error(`${this.propertyKey} was called ${callsWithMatchingArgs.length} times with ${expectedArgumentInvocation.prettyPrint()}`);
+            throw new Error(`${String(this.propertyKey)} was called ${callsWithMatchingArgs.length} times with ${expectedArgumentInvocation.prettyPrint()}`);
         }
     }
 
@@ -80,7 +80,7 @@ class TimesVerifier {
         const calls = this.repo.lookupCalls(this.propertyKey);
 
         if (calls.length !== this.count)
-            throw new Error(`${this.propertyKey} was was expected to be called ${this.count} times, but was called ${calls.length}`)
+            throw new Error(`${String(this.propertyKey)} was was expected to be called ${this.count} times, but was called ${calls.length}`)
     }
 
     //noinspection JSUnusedGlobalSymbols
@@ -93,7 +93,7 @@ class TimesVerifier {
             .filter(expectedCall => expectedArgumentInvocation.equivalentTo(expectedCall));
 
         if (callsWithMatchingArgs.length !== this.count) {
-            throw new Error(`${this.propertyKey} was called ${callsWithMatchingArgs.length} times with ${expectedArgumentInvocation.prettyPrint()} but was expected to be called ${this.count} times.`);
+            throw new Error(`${String(this.propertyKey)} was called ${callsWithMatchingArgs.length} times with ${expectedArgumentInvocation.prettyPrint()} but was expected to be called ${this.count} times.`);
         }
     }
 }

--- a/test/SafeMock.test.ts
+++ b/test/SafeMock.test.ts
@@ -439,6 +439,40 @@ describe('SafeMock', () => {
 
         describe('Multiple argument methods', () => {
 
+            describe('not known', () => {
+                type attributeList = 'foo' | 'bar' | 'foobar';
+                type attributeUpdate<K extends attributeList> = {
+                    [P in K]: string;
+                }
+
+                const testedTarget = {
+                    foo: 'fooVal',
+                    bar: 'barVal',
+        
+                }
+
+                interface AlienService {
+                    updateAlienAttribute<K extends attributeList>(attributes: attributeUpdate<K>): void
+                }
+
+                const mock: Mock<AlienService> = SafeMock.build<AlienService>();
+                mock.updateAlienAttribute(testedTarget);
+                verify(mock.updateAlienAttribute).calledWith(testedTarget);
+
+
+
+
+                interface O {
+                    foo?: string;
+                }
+                
+                function fails<K extends keyof O>(o: O, k: K) {
+                    var s: string = o[k]; // Previously allowed, now an error
+                                          // string | undefined is not assignable to a string
+                }
+
+
+            });
             describe('1 argument methods', () => {
                 it("throws an exception if called with different arguments", () => {
                     const mock: Mock<SomeService> = SafeMock.build<SomeService>();
@@ -686,6 +720,7 @@ describe('SafeMock', () => {
                 verify(mock.createSomethingOneArg).never.calledWith("call");
             });
         })
+
     });
 
     describe('verifying times called', () => {

--- a/test/SafeMock.test.ts
+++ b/test/SafeMock.test.ts
@@ -368,6 +368,30 @@ describe('SafeMock', () => {
     });
 
     describe('verifying calls', () => {
+
+        describe('calledWith argument', () => {
+            it('index siguature is subset of method argument', () => {
+                type attributeList = 'foo' | 'bar' | 'foobar';
+                type attributeUpdate<K extends attributeList> = {
+                    [P in K]: string;
+                }
+    
+                const testedTarget = {
+                    foo: 'fooVal',
+                    bar: 'barVal',
+                }
+    
+                interface alienService {
+                    updateAlienAttribute<K extends attributeList>(attributes: attributeUpdate<K>): void
+                }
+    
+                const mock: Mock<alienService> = SafeMock.build<alienService>();
+                mock.updateAlienAttribute(testedTarget);
+                // without partial put int he index.d.ts, following line does not compile
+                verify(mock.updateAlienAttribute).calledWith(testedTarget);
+            });
+        });
+
         describe('no argument methods', () => {
             it("throws an exception if Not Called", () => {
                 const mock: Mock<SomeService> = SafeMock.build<SomeService>();
@@ -439,40 +463,6 @@ describe('SafeMock', () => {
 
         describe('Multiple argument methods', () => {
 
-            describe('not known', () => {
-                type attributeList = 'foo' | 'bar' | 'foobar';
-                type attributeUpdate<K extends attributeList> = {
-                    [P in K]: string;
-                }
-
-                const testedTarget = {
-                    foo: 'fooVal',
-                    bar: 'barVal',
-        
-                }
-
-                interface AlienService {
-                    updateAlienAttribute<K extends attributeList>(attributes: attributeUpdate<K>): void
-                }
-
-                const mock: Mock<AlienService> = SafeMock.build<AlienService>();
-                mock.updateAlienAttribute(testedTarget);
-                verify(mock.updateAlienAttribute).calledWith(testedTarget);
-
-
-
-
-                interface O {
-                    foo?: string;
-                }
-                
-                function fails<K extends keyof O>(o: O, k: K) {
-                    var s: string = o[k]; // Previously allowed, now an error
-                                          // string | undefined is not assignable to a string
-                }
-
-
-            });
             describe('1 argument methods', () => {
                 it("throws an exception if called with different arguments", () => {
                     const mock: Mock<SomeService> = SafeMock.build<SomeService>();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,5 @@
     "inlineSources": true,
     "declaration": false,
     "alwaysStrict": true,
-    "suppressImplicitAnyIndexErrors": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "lib": [
       "es6"
     ],
+    "outDir": "build",
     "module": "commonjs",
     "target": "es5",
     "noImplicitAny": true,
@@ -11,6 +12,8 @@
     "noImplicitReturns": true,
     "sourceMap": true,
     "inlineSources": true,
-    "declaration": false
+    "declaration": false,
+    "alwaysStrict": true,
+    "suppressImplicitAnyIndexErrors": true
   }
 }


### PR DESCRIPTION
Hey, Matt,
Initially I want to use this PR to address the following issue:
         ` type attributeList = 'foo' | 'bar' | 'foobar';
                type attributeUpdate<K extends attributeList> = {
                    [P in K]: string;
                }
    
                const testedTarget = {
                    foo: 'fooVal',
                    bar: 'barVal',
                }
    
                interface alienService {
                    updateAlienAttribute<K extends attributeList>(attributes: attributeUpdate<K>): void
                }
    
                const mock: Mock<alienService> = SafeMock.build<alienService>();
                mock.updateAlienAttribute(testedTarget);
                // without partial put int he index.d.ts, following line does not compile
                verify(mock.updateAlienAttribute).calledWith(testedTarget);`

Without this PR, it has compile error on lastline. After a little bit playground, i found this break is introduced in typescript 2.7 by this break change: [link](https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#stricter-checking-for-indexed-access-generic-type-constraints)

Furthermore, this PR also upgrade typescript to latest 3.1.3 version. 
