### PR TITLE
Self documenting name for resolve argument

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,7 @@ export interface ReturnSetter<T> {
 }
 
 export interface PromiseReturnSetter<T> extends ReturnSetter<Promise<T>> {
-    resolve(rejection: T): void;
+    resolve(resolution: T): void;
     reject(rejection: any): void;
 }
 


### PR DESCRIPTION
If using an IDE it is odd to have a suggestion pop up with `rejection` when using the resolve method.