### PR TITLE
Fix messaging when params are undefined or nulls

### DIFF
--- a/src/ArgumentInvocation.ts
+++ b/src/ArgumentInvocation.ts
@@ -8,7 +8,10 @@ function inBraces(joiner: (a: any[]) => string) {
 }
 
 function isSpecialObject(arg: any): boolean {
-    let constructorName = arg.constructor.name;
+    if (arg === undefined || arg === null) {
+        return false;
+    }
+    const constructorName = arg.constructor.name;
     const notFound = -1;
     return primitives.indexOf(constructorName) === notFound;
 }

--- a/test/SafeMock.test.ts
+++ b/test/SafeMock.test.ts
@@ -435,6 +435,29 @@ describe('SafeMock', () => {
 
                 verify(mockedFunction).called()
             });
+
+            it('matches verify on undefined arguments', () => {
+                type explodingFn = (param: {} | undefined) => void;
+                const mockFn = SafeMock.mockFunction<explodingFn>('testFunction');
+
+                mockFn(undefined);
+
+                expect(() => {
+                    verify(mockFn).calledWith(5);
+                }).to.throw(`testFunction was not called with: (5)`);
+            });
+
+            it('matches verify on null arguments', () => {
+                type explodingFn = (param: {} | null) => void;
+                const mockFn = SafeMock.mockFunction<explodingFn>('testFunction');
+
+                mockFn(null);
+
+                expect(() => {
+                    verify(mockFn).calledWith(5);
+                }).to.throw(`testFunction was not called with: (5)
+       Other interactions with this mock: [(null)]`);
+            });
         });
 
         describe('Multiple argument methods', () => {


### PR DESCRIPTION
Hey Matt,

I found this issue during my journeys with SafeMock. It's something that has tripped me up a few times.

Any feedback is welcome. Specifically, let me know if the positioning of the test looks good and if I am missing any tests.